### PR TITLE
fix: trim first letter to fix version check

### DIFF
--- a/cmd/vulnx/clis/version.go
+++ b/cmd/vulnx/clis/version.go
@@ -1,6 +1,8 @@
 package clis
 
 import (
+	"strings"
+
 	"github.com/projectdiscovery/gologger"
 	updateutils "github.com/projectdiscovery/utils/update"
 	"github.com/spf13/cobra"
@@ -62,7 +64,7 @@ func showVersion() {
 		gologger.Info().Msgf("Current vulnx version %s %s", Version, description)
 
 		// If there's a newer version available, provide helpful information
-		if latestVersion != Version {
+		if latestVersion != strings.TrimPrefix(Version, "v") {
 			gologger.Info().Msg("To update vulnx, use:")
 			gologger.Info().Msg("vulnx --update  or  vulnx update")
 			gologger.Info().Msg("Or install via pdtm: pdtm -u vulnx")


### PR DESCRIPTION
When using `vulnx version` it suggests user to update because `Version = "v2.0.2"` while `latestVersion = "2.0.2"`

Fixed:
``` bash
vulnx  ❯ git:(fix-version-check) ./vulnx --silent version
[INF] Current vulnx version v2.0.2 (latest)
```
Not Fixed:
```
vulnx  ❯ git:(fix-version-check) ./vulnx --silent version
[INF] Current vulnx version v2.0.2 (latest)
[INF] To update vulnx, use:
[INF] vulnx --update  or  vulnx update
[INF] Or install via pdtm: pdtm -u vulnx
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version update detection by correctly comparing versions with or without a leading “v” prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->